### PR TITLE
pThunkRef is never NULL in  Shellcode

### DIFF
--- a/Manual Map Injector/injector.cpp
+++ b/Manual Map Injector/injector.cpp
@@ -284,7 +284,7 @@ void __stdcall Shellcode(MANUAL_MAPPING_DATA* pData) {
 			ULONG_PTR* pThunkRef = reinterpret_cast<ULONG_PTR*>(pBase + pImportDescr->OriginalFirstThunk);
 			ULONG_PTR* pFuncRef = reinterpret_cast<ULONG_PTR*>(pBase + pImportDescr->FirstThunk);
 
-			if (!((ULONG64)pThunkRef - (ULONG64)pBase))
+			if (!pImportDescr->OriginalFirstThunk)
 				pThunkRef = pFuncRef;
 
 			for (; *pThunkRef; ++pThunkRef, ++pFuncRef) {

--- a/Manual Map Injector/injector.cpp
+++ b/Manual Map Injector/injector.cpp
@@ -284,7 +284,7 @@ void __stdcall Shellcode(MANUAL_MAPPING_DATA* pData) {
 			ULONG_PTR* pThunkRef = reinterpret_cast<ULONG_PTR*>(pBase + pImportDescr->OriginalFirstThunk);
 			ULONG_PTR* pFuncRef = reinterpret_cast<ULONG_PTR*>(pBase + pImportDescr->FirstThunk);
 
-			if (!pThunkRef)
+			if (!((ULONG64)pThunkRef - (ULONG64)pBase))
 				pThunkRef = pFuncRef;
 
 			for (; *pThunkRef; ++pThunkRef, ++pFuncRef) {


### PR DESCRIPTION
Hello,

See the code below in injector.cpp L284
```c++
ULONG_PTR* pThunkRef = reinterpret_cast<ULONG_PTR*>(pBase + pImportDescr->OriginalFirstThunk);
ULONG_PTR* pFuncRef = reinterpret_cast<ULONG_PTR*>(pBase + pImportDescr->FirstThunk);

if (!pThunkRef)
   pThunkRef = pFuncRef;
```
This check checks whether the ``pThunkRef`` pointer is NULL, but this will never happen as pBase itself is never NULL. 
Instead, we either should check whether ``pImportDescr->OriginalFirstThunk`` is NULL.
